### PR TITLE
Fix role syntax for newer ansible versions

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -29,7 +29,7 @@ galaxy_info:
     - name: opensuse
       versions:
         - all
-  categories:
+  galaxy_tags:
     - dns
     - resolution
 dependencies: []

--- a/tasks/resolvconf-apt.yml
+++ b/tasks/resolvconf-apt.yml
@@ -20,7 +20,7 @@
     update_cache: yes
     cache_valid_time: "{{ cache_timeout }}"
   register: install_packages
-  until: install_packages|success
+  until: install_packages is success
   retries: 5
   delay: 2
   with_items: "{{ resolvconf_packages }}"


### PR DESCRIPTION
Using success filter has been deprecated in favor of using the test.

Also updated meta to pass linters tests.